### PR TITLE
Implement docli-kb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,9 @@ dependencies = [
  "minijinja",
  "regex",
  "serde",
+ "serde_json",
  "serde_yaml",
+ "tempfile",
 ]
 
 [[package]]

--- a/docli-kb/Cargo.toml
+++ b/docli-kb/Cargo.toml
@@ -10,4 +10,6 @@ docli-core = { path = "../docli-core" }
 minijinja.workspace = true
 regex.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 serde_yaml.workspace = true
+tempfile.workspace = true

--- a/docli-kb/src/lib.rs
+++ b/docli-kb/src/lib.rs
@@ -1,3 +1,9 @@
-//! Phase 0 stub for knowledge-base resolution and templating.
+//! Knowledge-base resolution and template rendering.
 
-pub const CRATE_NAME: &str = "docli-kb";
+pub mod resolver;
+pub mod rules;
+pub mod template;
+
+pub use resolver::{KbResolver, KbValidationIssue};
+pub use rules::{load_rules, KbRule, RuleMetadata};
+pub use template::render_template;

--- a/docli-kb/src/resolver.rs
+++ b/docli-kb/src/resolver.rs
@@ -1,0 +1,131 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use docli_core::DocliError;
+
+use crate::rules::load_rules;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KbValidationIssue {
+    pub path: PathBuf,
+    pub message: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct KbResolver {
+    kb_root: PathBuf,
+}
+
+impl KbResolver {
+    pub fn new(kb_root: impl Into<PathBuf>) -> Self {
+        Self {
+            kb_root: kb_root.into(),
+        }
+    }
+
+    pub fn kb_root(&self) -> &Path {
+        &self.kb_root
+    }
+
+    pub fn templates_root(&self) -> PathBuf {
+        self.kb_root.join("templates/docli")
+    }
+
+    pub fn resolve_uri(&self, uri: &str) -> Result<PathBuf, DocliError> {
+        let relative = uri
+            .strip_prefix("kb://")
+            .ok_or_else(|| DocliError::RefNotFound {
+                reference: uri.to_string(),
+            })?;
+        let path = self.templates_root().join(relative);
+        if !path.exists() {
+            return Err(DocliError::RefNotFound {
+                reference: uri.to_string(),
+            });
+        }
+        Ok(path)
+    }
+
+    pub fn list_entries(&self, category: &str) -> Result<Vec<String>, DocliError> {
+        let directory = self.templates_root().join(category);
+        let entries = fs::read_dir(&directory).map_err(|_| DocliError::TemplateNotFound {
+            template: category.to_string(),
+        })?;
+        let mut names = entries
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_type().ok().is_some_and(|kind| kind.is_file()))
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        names.sort();
+        Ok(names)
+    }
+
+    pub fn validate_all(&self) -> Result<Vec<KbValidationIssue>, DocliError> {
+        let mut issues = Vec::new();
+        let templates_root = self.templates_root();
+
+        for category in ["styles", "specs", "sections", "assets", "rules", "examples"] {
+            let path = templates_root.join(category);
+            if !path.exists() {
+                issues.push(KbValidationIssue {
+                    path,
+                    message: format!("missing KB category directory: {category}"),
+                });
+            }
+        }
+
+        for rule in load_rules(&templates_root.join("rules"))? {
+            if rule.metadata.title.trim().is_empty() {
+                issues.push(KbValidationIssue {
+                    path: rule.path,
+                    message: "rule title must not be empty".to_string(),
+                });
+            }
+        }
+
+        Ok(issues)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::KbResolver;
+
+    #[test]
+    fn resolves_kb_uris_into_templates_namespace() {
+        let dir = tempdir().unwrap();
+        let target = dir
+            .path()
+            .join("templates/docli/sections/cuped-methodology.yaml");
+        fs::create_dir_all(target.parent().unwrap()).unwrap();
+        fs::write(&target, "section: ok").unwrap();
+
+        let resolver = KbResolver::new(dir.path());
+        let resolved = resolver
+            .resolve_uri("kb://sections/cuped-methodology.yaml")
+            .unwrap();
+
+        assert_eq!(resolved, target);
+    }
+
+    #[test]
+    fn lists_entries_in_a_category() {
+        let dir = tempdir().unwrap();
+        let styles = dir.path().join("templates/docli/styles");
+        fs::create_dir_all(&styles).unwrap();
+        fs::write(styles.join("a.yaml"), "").unwrap();
+        fs::write(styles.join("b.yaml"), "").unwrap();
+
+        let resolver = KbResolver::new(dir.path());
+        assert_eq!(
+            resolver.list_entries("styles").unwrap(),
+            vec!["a.yaml".to_string(), "b.yaml".to_string()]
+        );
+    }
+}

--- a/docli-kb/src/rules.rs
+++ b/docli-kb/src/rules.rs
@@ -1,0 +1,105 @@
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use docli_core::DocliError;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RuleMetadata {
+    pub title: String,
+    #[serde(default)]
+    pub severity: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KbRule {
+    pub path: PathBuf,
+    pub metadata: RuleMetadata,
+    pub body: String,
+}
+
+pub fn load_rules(directory: &Path) -> Result<Vec<KbRule>, DocliError> {
+    if !directory.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut rules = Vec::new();
+    for entry in fs::read_dir(directory).map_err(|error| DocliError::TemplateNotFound {
+        template: error.to_string(),
+    })? {
+        let entry = entry.map_err(|error| DocliError::TemplateNotFound {
+            template: error.to_string(),
+        })?;
+        if !entry
+            .file_type()
+            .map_err(|error| DocliError::TemplateNotFound {
+                template: error.to_string(),
+            })?
+            .is_file()
+        {
+            continue;
+        }
+
+        let path = entry.path();
+        let content = fs::read_to_string(&path).map_err(|error| DocliError::TemplateNotFound {
+            template: error.to_string(),
+        })?;
+        let (front_matter, body) =
+            split_front_matter(&content).ok_or_else(|| DocliError::InvalidSpec {
+                message: format!("rule file missing YAML front matter: {}", path.display()),
+            })?;
+        let metadata = serde_yaml::from_str::<RuleMetadata>(front_matter).map_err(|error| {
+            DocliError::InvalidSpec {
+                message: error.to_string(),
+            }
+        })?;
+        rules.push(KbRule {
+            path,
+            metadata,
+            body: body.to_string(),
+        });
+    }
+
+    rules.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(rules)
+}
+
+fn split_front_matter(content: &str) -> Option<(&str, &str)> {
+    let remainder = content.strip_prefix("---\n")?;
+    let end = remainder.find("\n---\n")?;
+    let front_matter = &remainder[..end];
+    let body = &remainder[end + 5..];
+    Some((front_matter, body))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::load_rules;
+
+    #[test]
+    fn loads_markdown_rules_with_yaml_front_matter() {
+        let dir = tempdir().unwrap();
+        let rule = dir.path().join("check.md");
+        fs::write(
+            &rule,
+            "---\ntitle: Example Rule\nseverity: warning\n---\nRule body",
+        )
+        .unwrap();
+
+        let rules = load_rules(dir.path()).unwrap();
+
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].metadata.title, "Example Rule");
+        assert_eq!(rules[0].body, "Rule body");
+    }
+}

--- a/docli-kb/src/template.rs
+++ b/docli-kb/src/template.rs
@@ -1,0 +1,56 @@
+use minijinja::{Environment, UndefinedBehavior};
+use serde_json::{Map, Value};
+
+use docli_core::DocliError;
+
+pub fn render_template(content: &str, vars: &Map<String, Value>) -> Result<String, DocliError> {
+    let mut environment = Environment::new();
+    environment.set_undefined_behavior(UndefinedBehavior::Strict);
+    environment
+        .add_template("template", content)
+        .map_err(|error| DocliError::InvalidSpec {
+            message: error.to_string(),
+        })?;
+
+    let template =
+        environment
+            .get_template("template")
+            .map_err(|error| DocliError::InvalidSpec {
+                message: error.to_string(),
+            })?;
+
+    let mut context = vars.clone();
+    context.insert("date".to_string(), Value::String("today".to_string()));
+    template.render(Value::Object(context)).map_err(|error| {
+        let message = error.to_string();
+        if message.contains("undefined value") {
+            DocliError::TemplateVarMissing { variable: message }
+        } else {
+            DocliError::InvalidSpec { message }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Map, Value};
+
+    use super::render_template;
+
+    #[test]
+    fn renders_minijinja_templates_with_cli_vars() {
+        let mut vars = Map::new();
+        vars.insert("name".to_string(), Value::String("docli".to_string()));
+        vars.insert("count".to_string(), Value::Number(3.into()));
+
+        let rendered = render_template(
+            "name: {{ name }}\ncount: {{ count }}\ndate: {{ date }}",
+            &vars,
+        )
+        .unwrap();
+
+        assert!(rendered.contains("name: docli"));
+        assert!(rendered.contains("count: 3"));
+        assert!(rendered.contains("date: today"));
+    }
+}


### PR DESCRIPTION
## Summary
- add KB URI resolution, directory listing, and validation over the templates/docli namespace
- load markdown rules with YAML front matter and expose a structured rule model
- implement strict minijinja rendering with serde_json vars and an injected date variable

## Verification
- cargo test -p docli-kb
- cargo build --workspace

Depends on #22
Closes #5