### PR TITLE
Issue #4: Implement docli-schema

### DIFF
--- a/docli-schema/Cargo.toml
+++ b/docli-schema/Cargo.toml
@@ -10,6 +10,11 @@ docli-core = { path = "../docli-core" }
 docli-query = { path = "../docli-query" }
 ooxmlsdk.workspace = true
 quick-xml.workspace = true
+roxmltree.workspace = true
 schemars.workspace = true
 serde.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+zip.workspace = true

--- a/docli-schema/src/invariants.rs
+++ b/docli-schema/src/invariants.rs
@@ -1,0 +1,213 @@
+use std::collections::{HashMap, HashSet};
+
+use docli_core::Package;
+
+use crate::ValidationIssue;
+
+pub fn check_invariants(package: &Package) -> Vec<ValidationIssue> {
+    let mut issues = Vec::new();
+    let mut ids: HashMap<String, String> = HashMap::new();
+
+    for (part_path, bytes) in &package.xml_parts {
+        let xml = String::from_utf8_lossy(bytes);
+        let document = match roxmltree::Document::parse(&xml) {
+            Ok(document) => document,
+            Err(error) => {
+                issues.push(ValidationIssue::error(
+                    "invalid-xml",
+                    error.to_string(),
+                    Some(part_path),
+                ));
+                continue;
+            }
+        };
+
+        for node in document.descendants().filter(|node| node.is_element()) {
+            for attribute in node.attributes() {
+                if attribute.name() == "id"
+                    && attribute
+                        .namespace()
+                        .is_some_and(|namespace| namespace.contains("wordprocessingml"))
+                {
+                    if let Some(previous_part) =
+                        ids.insert(attribute.value().to_string(), part_path.clone())
+                    {
+                        issues.push(ValidationIssue::error(
+                            "duplicate-word-id",
+                            format!(
+                                "duplicate w:id {} found in {} and {}",
+                                attribute.value(),
+                                previous_part,
+                                part_path
+                            ),
+                            Some(part_path),
+                        ));
+                    }
+                }
+            }
+
+            match node.tag_name().name() {
+                "ins" | "del" => {
+                    if node
+                        .ancestors()
+                        .skip(1)
+                        .any(|ancestor| ancestor.has_tag_name("r") || ancestor.has_tag_name("t"))
+                    {
+                        issues.push(ValidationIssue::error(
+                            "invalid-tracked-change-nesting",
+                            "tracked changes may not be nested inside w:r or w:t",
+                            Some(part_path),
+                        ));
+                    }
+                }
+                "commentRangeStart" | "commentRangeEnd" => {
+                    if node.parent().is_some_and(|parent| parent.has_tag_name("r")) {
+                        issues.push(ValidationIssue::error(
+                            "invalid-comment-range-placement",
+                            "comment range markers must be siblings of w:r, not children",
+                            Some(part_path),
+                        ));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let content_types = declared_content_types(package);
+    let relationships = package
+        .xml_parts
+        .get("word/_rels/document.xml.rels")
+        .and_then(|bytes| parse_relationship_targets(bytes).ok())
+        .unwrap_or_default();
+
+    if package.inventory.entries.contains_key("word/comments.xml")
+        && !content_types.contains("word/comments.xml")
+    {
+        issues.push(ValidationIssue::error(
+            "missing-comments-content-type",
+            "word/comments.xml exists but is not declared in [Content_Types].xml",
+            Some("[Content_Types].xml"),
+        ));
+    }
+
+    for target in relationships {
+        if target.starts_with("media/") {
+            let extension = target.rsplit('.').next().unwrap_or_default();
+            if !content_types.contains(&format!("*.{extension}")) {
+                issues.push(ValidationIssue::warning(
+                    "missing-media-content-type",
+                    format!("missing content type default for media extension {extension}"),
+                    Some("[Content_Types].xml"),
+                ));
+            }
+        }
+    }
+
+    issues
+}
+
+fn declared_content_types(package: &Package) -> HashSet<String> {
+    let Some(content_types) = package.xml_parts.get("[Content_Types].xml") else {
+        return HashSet::new();
+    };
+    let xml = String::from_utf8_lossy(content_types);
+    let mut entries = HashSet::new();
+    for line in xml.lines() {
+        if let Some(part_name) = extract_attribute(line, "PartName") {
+            entries.insert(part_name.trim_start_matches('/').to_string());
+        }
+        if let Some(extension) = extract_attribute(line, "Extension") {
+            entries.insert(format!("*.{extension}"));
+        }
+    }
+    entries
+}
+
+fn parse_relationship_targets(bytes: &[u8]) -> Result<Vec<String>, roxmltree::Error> {
+    let xml = String::from_utf8_lossy(bytes);
+    let document = roxmltree::Document::parse(&xml)?;
+    Ok(document
+        .descendants()
+        .filter(|node| node.has_tag_name("Relationship"))
+        .filter_map(|node| node.attribute("Target").map(ToString::to_string))
+        .collect())
+}
+
+fn extract_attribute<'a>(line: &'a str, attr: &str) -> Option<&'a str> {
+    let marker = format!("{attr}=\"");
+    let start = line.find(&marker)?;
+    let rest = &line[start + marker.len()..];
+    let end = rest.find('"')?;
+    Some(&rest[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::File, io::Write, path::PathBuf};
+
+    use docli_core::Package;
+    use tempfile::NamedTempFile;
+    use zip::{write::SimpleFileOptions, ZipWriter};
+
+    use super::check_invariants;
+
+    fn build_docx(document_xml: &str, rels_xml: &str, content_types: &str) -> PathBuf {
+        let temp = NamedTempFile::new().unwrap();
+        let path = temp.path().to_path_buf();
+        let file = File::create(&path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let options = SimpleFileOptions::default();
+        zip.start_file("[Content_Types].xml", options).unwrap();
+        zip.write_all(content_types.as_bytes()).unwrap();
+        zip.start_file("_rels/.rels", options).unwrap();
+        zip.write_all(rels_xml.as_bytes()).unwrap();
+        zip.start_file("word/document.xml", options).unwrap();
+        zip.write_all(document_xml.as_bytes()).unwrap();
+        zip.start_file("word/_rels/document.xml.rels", options)
+            .unwrap();
+        zip.write_all(rels_xml.as_bytes()).unwrap();
+        zip.finish().unwrap();
+        let (_file, kept_path) = temp.keep().unwrap();
+        kept_path
+    }
+
+    #[test]
+    fn reports_duplicate_word_ids() {
+        let document = r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+            <w:body>
+              <w:p><w:bookmarkStart w:id="7" w:name="a"/></w:p>
+              <w:p><w:bookmarkStart w:id="7" w:name="b"/></w:p>
+            </w:body>
+        </w:document>"#;
+        let rels = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>"#;
+        let types = r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+            <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+            <Default Extension="xml" ContentType="application/xml"/>
+            <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+        </Types>"#;
+        let package = Package::open(build_docx(document, rels, types)).unwrap();
+
+        let issues = check_invariants(&package);
+        assert!(issues.iter().any(|issue| issue.code == "duplicate-word-id"));
+    }
+
+    #[test]
+    fn reports_invalid_tracked_change_nesting() {
+        let document = r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+            <w:body><w:p><w:r><w:ins/></w:r></w:p></w:body>
+        </w:document>"#;
+        let rels = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>"#;
+        let types = r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+            <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+            <Default Extension="xml" ContentType="application/xml"/>
+            <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+        </Types>"#;
+        let package = Package::open(build_docx(document, rels, types)).unwrap();
+
+        let issues = check_invariants(&package);
+        assert!(issues
+            .iter()
+            .any(|issue| issue.code == "invalid-tracked-change-nesting"));
+    }
+}

--- a/docli-schema/src/lib.rs
+++ b/docli-schema/src/lib.rs
@@ -1,3 +1,52 @@
-//! Phase 0 stub for validation and repair logic.
+//! Validation and repair helpers for DOCX packages.
 
-pub const CRATE_NAME: &str = "docli-schema";
+pub mod invariants;
+pub mod redline;
+pub mod repair;
+pub mod structural;
+
+pub use invariants::check_invariants;
+pub use redline::validate_redlines;
+pub use repair::{ensure_xml_space_preserve, repair_durable_id_overflow};
+pub use structural::validate_structure;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationSeverity {
+    Warning,
+    Error,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ValidationIssue {
+    pub code: String,
+    pub message: String,
+    pub severity: ValidationSeverity,
+    pub part: Option<String>,
+}
+
+impl ValidationIssue {
+    pub fn error(code: impl Into<String>, message: impl Into<String>, part: Option<&str>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            severity: ValidationSeverity::Error,
+            part: part.map(ToString::to_string),
+        }
+    }
+
+    pub fn warning(
+        code: impl Into<String>,
+        message: impl Into<String>,
+        part: Option<&str>,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            severity: ValidationSeverity::Warning,
+            part: part.map(ToString::to_string),
+        }
+    }
+}

--- a/docli-schema/src/redline.rs
+++ b/docli-schema/src/redline.rs
@@ -1,0 +1,7 @@
+use docli_core::Package;
+
+use crate::ValidationIssue;
+
+pub fn validate_redlines(_package: &Package) -> Vec<ValidationIssue> {
+    Vec::new()
+}

--- a/docli-schema/src/repair.rs
+++ b/docli-schema/src/repair.rs
@@ -1,0 +1,189 @@
+use docli_core::DocliError;
+use quick_xml::{
+    events::{BytesStart, Event},
+    Reader, Writer,
+};
+
+pub fn ensure_xml_space_preserve(xml: &[u8]) -> Result<Vec<u8>, DocliError> {
+    let mut reader = Reader::from_reader(xml);
+    reader.config_mut().trim_text(false);
+    let mut writer = Writer::new(Vec::new());
+    let mut buf = Vec::new();
+    let mut pending_text = None::<BytesStart<'static>>;
+
+    loop {
+        match reader
+            .read_event_into(&mut buf)
+            .map_err(|error| DocliError::InvalidDocx {
+                message: error.to_string(),
+            })? {
+            Event::Start(start) if start.local_name().as_ref() == b"t" => {
+                pending_text = Some(start.into_owned());
+            }
+            Event::Text(text) => {
+                if let Some(start) = pending_text.take() {
+                    let content = text.unescape().map_err(|error| DocliError::InvalidDocx {
+                        message: error.to_string(),
+                    })?;
+                    let needs_preserve = content.starts_with(char::is_whitespace)
+                        || content.ends_with(char::is_whitespace);
+                    let start = if needs_preserve && !has_xml_space(&start) {
+                        with_attribute(start, ("xml:space", "preserve"))
+                    } else {
+                        start
+                    };
+                    writer.write_event(Event::Start(start)).map_err(|error| {
+                        DocliError::InvalidDocx {
+                            message: error.to_string(),
+                        }
+                    })?;
+                }
+                writer
+                    .write_event(Event::Text(text))
+                    .map_err(|error| DocliError::InvalidDocx {
+                        message: error.to_string(),
+                    })?;
+            }
+            Event::End(end) => {
+                if let Some(start) = pending_text.take() {
+                    writer.write_event(Event::Start(start)).map_err(|error| {
+                        DocliError::InvalidDocx {
+                            message: error.to_string(),
+                        }
+                    })?;
+                }
+                writer
+                    .write_event(Event::End(end))
+                    .map_err(|error| DocliError::InvalidDocx {
+                        message: error.to_string(),
+                    })?;
+            }
+            Event::Empty(start) => {
+                let repaired = repair_id_attributes(start.into_owned());
+                writer
+                    .write_event(Event::Empty(repaired))
+                    .map_err(|error| DocliError::InvalidDocx {
+                        message: error.to_string(),
+                    })?;
+            }
+            Event::Start(start) => {
+                let repaired = repair_id_attributes(start.into_owned());
+                writer
+                    .write_event(Event::Start(repaired))
+                    .map_err(|error| DocliError::InvalidDocx {
+                        message: error.to_string(),
+                    })?;
+            }
+            Event::Eof => break,
+            event => {
+                writer
+                    .write_event(event)
+                    .map_err(|error| DocliError::InvalidDocx {
+                        message: error.to_string(),
+                    })?;
+            }
+        }
+        buf.clear();
+    }
+
+    Ok(writer.into_inner())
+}
+
+pub fn repair_durable_id_overflow(xml: &[u8]) -> Result<Vec<u8>, DocliError> {
+    let mut reader = Reader::from_reader(xml);
+    reader.config_mut().trim_text(false);
+    let mut writer = Writer::new(Vec::new());
+    let mut buf = Vec::new();
+
+    loop {
+        match reader
+            .read_event_into(&mut buf)
+            .map_err(|error| DocliError::InvalidDocx {
+                message: error.to_string(),
+            })? {
+            Event::Start(start) => writer
+                .write_event(Event::Start(repair_id_attributes(start.into_owned())))
+                .map_err(|error| DocliError::InvalidDocx {
+                    message: error.to_string(),
+                })?,
+            Event::Empty(start) => writer
+                .write_event(Event::Empty(repair_id_attributes(start.into_owned())))
+                .map_err(|error| DocliError::InvalidDocx {
+                    message: error.to_string(),
+                })?,
+            Event::Eof => break,
+            event => writer
+                .write_event(event)
+                .map_err(|error| DocliError::InvalidDocx {
+                    message: error.to_string(),
+                })?,
+        }
+        buf.clear();
+    }
+
+    Ok(writer.into_inner())
+}
+
+fn has_xml_space(start: &BytesStart<'_>) -> bool {
+    start
+        .attributes()
+        .flatten()
+        .any(|attribute| attribute.key.as_ref() == b"xml:space")
+}
+
+fn with_attribute(mut start: BytesStart<'static>, attr: (&str, &str)) -> BytesStart<'static> {
+    start.push_attribute(attr);
+    start
+}
+
+fn repair_id_attributes(start: BytesStart<'static>) -> BytesStart<'static> {
+    let name = start.name().as_ref().to_vec();
+    let mut rebuilt = BytesStart::new(String::from_utf8_lossy(&name).into_owned());
+    let mut next_generated = 0x1000_0000_u32;
+
+    for attribute in start.attributes().flatten() {
+        let key = attribute.key.as_ref().to_vec();
+        let value = String::from_utf8_lossy(attribute.value.as_ref()).into_owned();
+        let repaired = if key.ends_with(b"paraId") || key.ends_with(b"durableId") {
+            repair_id_value(&value, &mut next_generated)
+        } else {
+            value
+        };
+        let key = String::from_utf8_lossy(&key).into_owned();
+        rebuilt.push_attribute((key.as_str(), repaired.as_str()));
+    }
+
+    rebuilt
+}
+
+fn repair_id_value(value: &str, next_generated: &mut u32) -> String {
+    let parsed = u32::from_str_radix(value, 16).unwrap_or(0);
+    if parsed < 0x7FFF_FFFF {
+        return value.to_string();
+    }
+
+    let repaired = format!("{:08X}", *next_generated);
+    *next_generated += 1;
+    repaired
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_xml_space_preserve, repair_durable_id_overflow};
+
+    #[test]
+    fn adds_xml_space_preserve_for_whitespace_text_nodes() {
+        let input = br#"<w:document xmlns:w="x"><w:body><w:p><w:r><w:t> leading</w:t></w:r></w:p></w:body></w:document>"#;
+        let repaired = String::from_utf8(ensure_xml_space_preserve(input).unwrap()).unwrap();
+
+        assert!(repaired.contains(r#"xml:space="preserve""#));
+    }
+
+    #[test]
+    fn repairs_overflowing_para_ids() {
+        let input = br#"<w:document xmlns:w14="x"><w:p w14:paraId="FFFFFFFF"/></w:document>"#;
+        let repaired = String::from_utf8(repair_durable_id_overflow(input).unwrap()).unwrap();
+
+        assert!(repaired.contains(r#"w14:paraId="10000000""#));
+    }
+}

--- a/docli-schema/src/structural.rs
+++ b/docli-schema/src/structural.rs
@@ -1,0 +1,109 @@
+use std::collections::HashSet;
+
+use docli_core::Package;
+
+use crate::ValidationIssue;
+
+pub fn validate_structure(package: &Package) -> Vec<ValidationIssue> {
+    let mut issues = Vec::new();
+
+    for required in [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "word/document.xml",
+        "word/_rels/document.xml.rels",
+    ] {
+        if !package.inventory.entries.contains_key(required) {
+            issues.push(ValidationIssue::error(
+                "missing-required-part",
+                format!("required package part is missing: {required}"),
+                Some(required),
+            ));
+        }
+    }
+
+    if let Some(content_types) = package.xml_parts.get("[Content_Types].xml") {
+        let xml = String::from_utf8_lossy(content_types);
+        if !xml.contains("Extension=\"rels\"") {
+            issues.push(ValidationIssue::error(
+                "missing-content-type-default",
+                "content types missing rels default registration",
+                Some("[Content_Types].xml"),
+            ));
+        }
+        if !xml.contains("Extension=\"xml\"") {
+            issues.push(ValidationIssue::error(
+                "missing-content-type-default",
+                "content types missing xml default registration",
+                Some("[Content_Types].xml"),
+            ));
+        }
+        if !xml.contains("PartName=\"/word/document.xml\"") {
+            issues.push(ValidationIssue::error(
+                "missing-content-type-override",
+                "content types missing document.xml override",
+                Some("[Content_Types].xml"),
+            ));
+        }
+    }
+
+    let overrides = collect_content_type_overrides(package);
+    for part in [
+        "word/comments.xml",
+        "word/endnotes.xml",
+        "word/footnotes.xml",
+    ] {
+        if package.inventory.entries.contains_key(part) && !overrides.contains(part) {
+            issues.push(ValidationIssue::warning(
+                "missing-content-type-override",
+                format!("missing override for optional part {part}"),
+                Some("[Content_Types].xml"),
+            ));
+        }
+    }
+
+    issues
+}
+
+fn collect_content_type_overrides(package: &Package) -> HashSet<String> {
+    let Some(content_types) = package.xml_parts.get("[Content_Types].xml") else {
+        return HashSet::new();
+    };
+    let xml = String::from_utf8_lossy(content_types);
+    xml.lines()
+        .filter_map(|line| extract_part_name(line))
+        .map(|part| part.trim_start_matches('/').to_string())
+        .collect()
+}
+
+fn extract_part_name(line: &str) -> Option<&str> {
+    let marker = "PartName=\"";
+    let start = line.find(marker)?;
+    let rest = &line[start + marker.len()..];
+    let end = rest.find('"')?;
+    Some(&rest[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use docli_core::Package;
+
+    use super::validate_structure;
+
+    fn fixture_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../tests/fixtures/minimal.docx")
+    }
+
+    #[test]
+    fn reports_missing_document_relationship_part() {
+        let package = Package::open(fixture_path()).unwrap();
+        let issues = validate_structure(&package);
+
+        assert!(issues.iter().any(|issue| {
+            issue.code == "missing-required-part"
+                && issue.part.as_deref() == Some("word/_rels/document.xml.rels")
+        }));
+    }
+}


### PR DESCRIPTION
## Summary
- Structural validation (required parts + content-type checks)
- Hard invariant checks (duplicate w:id, tracked-change nesting, comment range placement, relationship consistency)
- Auto-repair (xml:space="preserve", paraId/durableId overflow via quick-xml streaming)
- Redline stub for Phase 3
- 5 unit tests, minimal.docx test fixture

Closes #4

## Test plan
- [x] `cargo test -p docli-schema` — 5 tests passing
- [x] `cargo build --workspace` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)